### PR TITLE
Remove the global reference to tape

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,9 +77,6 @@ test.skip = function (name, fn, _before, _after) {
   return test(name, fn, _before, _after, false, true);
 };
 
-// Allow consumers of `tapes` to patch the core `tape` library.
-test.Test = tape.Test;
-
 function runWrapperFns (fns, callback) {
   callback = callback || function () {};
 


### PR DESCRIPTION
Surely monkeypatching can occur by working on tape directly?

Global reference of tape breaks the directions from the README:

``` javascript
var tape = require('tape');
var tapes = require('tapes'); // Breaks here without global tape
var test = tapes(tape);
```
